### PR TITLE
Add build.bat script to make releases with exe instead of python files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+dist
+build
+*.exe
+*.spec
+*.zip

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,2 @@
+pyinstaller -F ResoniteSpotipy.py
+tar -a -c -f ResoniteSpotipy.zip IDs.txt -C dist ResoniteSpotipy.exe

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+websockets
+asyncio
+spotipy
+pyinstaller


### PR DESCRIPTION
feat: Add build batch script
feat: Add python requirements.txt file
feat: Add .gitignore file for build artifacts

Hey Jay!
I believe these simple changes could make Resonite Spotipy a lot more user friendly as it will allow you to make releases of it with compiled exes instead of requiring users to have python installed and installing the required packages and such.

The script uses the `pyinstaller` package and builds the python script with all dependencies into an exe file. 
Then it creates a zip file with the exe and the `IDs.txt` 