### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Here's the Resonite record link for the Resonite Spotipy audio player:
 
 ## Prerequisites
 You'll need these Python packages: *websockets*, *asyncio*, *spotipy*. You'll also need Python 3.9 at least.
-- To install these, run this command: ```pip install websockets asyncio spotipy```
+- To install these, run this command: ```py -m pip install websockets asyncio spotipy```
 
 ## How to setup your Spotify application
 **You'll need Spotify Premium to be able to do this!**


### PR DESCRIPTION
This uses Python’s built-in module runner to access pip, bypassing the need to call pip directly.

Else I get `pip: The term 'pip' is not recognized as a name of a cmdlet, function, script file, or executable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.`